### PR TITLE
sairedis: clean syncd-vs before making syncd

### DIFF
--- a/make/sairedis/Makefile
+++ b/make/sairedis/Makefile
@@ -11,6 +11,7 @@ step1:
 	cd $(SAIREDIS_DIR) && dpkg-buildpackage -us -uc -b && cd ../ && dpkg -i *.deb && cp *.deb /tmp/
 	patchelf --set-soname libsai.so /usr/lib/x86_64-linux-gnu/libsaivs.so.0.0.0
 	cd /usr/lib/x86_64-linux-gnu/ && ln -s libsaivs.so libsai.so
+	-$(MAKE) -C $(SAIREDIS_DIR)/syncd clean # clean up syncd-vs build in step1 ( TODO: use dh_auto_clean? )
 
 # step2 builds the syncd package without VS option enabled
 # the syncd executable links to libsai.so which is actually libsaivs.so


### PR DESCRIPTION
syncd build is bypassed if we don't clean syncd-vs explicitly

Signed-off-by: Wataru Ishida <ishida@nel-america.com>